### PR TITLE
feat: moving Hush! from a private repository to a public one

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,9 +11,9 @@ author:
 To install Hush! for use in your project, install it like this:
 
 +++ Yarn
-`yarn add -D @kernpunkt/hush`
+`yarn add -D hush-cli`
 +++ NPM
-`npm install --dev @kernpunkt/hush`
+`npm install --dev hush-cli`
 +++
 
 !!!

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kernpunkt/hush",
+  "name": "hush-cli",
   "description": "Command line tool to store and retrieve the contents of .env files in AWS SecretsManager.",
   "author": {
     "name": "Jörn Meyer",
@@ -10,13 +10,6 @@
   "license": "MIT",
   "bin": {
     "hush": "dist/hush.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kernpunkt/hush.git"
-  },
-  "publishConfig": {
-    "@kernpunkt:registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",


### PR DESCRIPTION
BREAKING CHANGE: from now on, please use the npm package hush-cli.